### PR TITLE
2016년

### DIFF
--- a/Programmers/Lv. 1/2016년.js
+++ b/Programmers/Lv. 1/2016년.js
@@ -1,0 +1,3 @@
+function solution(a, b) {
+  return new Date(2016, a - 1, b).toString().slice(0, 3).toUpperCase();
+}


### PR DESCRIPTION
[new Date() MDN](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Date/Date)

월을 받을 때, `-1`을 해준 이유는,
`monthIndex` 즉 월의 인덱스 값을 넣어야하기 때문이다! 
(1월을 나타내는 0부터 12월을 나타내는 11까지)